### PR TITLE
Update main.tf

### DIFF
--- a/networking/main.tf
+++ b/networking/main.tf
@@ -83,7 +83,7 @@ resource "aws_route_table" "rt_private" {
     vpc_id         = aws_vpc.main.id
     route {
         cidr_block = "0.0.0.0/0"
-        gateway_id = (
+        nat_gateway_id = (
             local.nat_gw_count > 2
             ? aws_nat_gateway.nat_public[count.index].id
             : aws_nat_gateway.nat_public[0].id


### PR DESCRIPTION
Update gateway_id to nat_gateway_id to prevent a changeset for every terraform plan

Such a changeset as the following is always returned when using this module:

```
 # module.networking.aws_route_table.rt_private[0] will be updated in-place
  ~ resource "aws_route_table" "rt_private" {
        id               = "rtb-xxxxxxxxx"
      ~ route            = [
          - {
              - carrier_gateway_id         = ""
              - cidr_block                 = "0.0.0.0/0"
              - core_network_arn           = ""
              - destination_prefix_list_id = ""
              - egress_only_gateway_id     = ""
              - gateway_id                 = ""
              - ipv6_cidr_block            = ""
              - local_gateway_id           = ""
              - nat_gateway_id             = "nat-xxxxxxxxxx"
              - network_interface_id       = ""
              - transit_gateway_id         = ""
              - vpc_endpoint_id            = ""
              - vpc_peering_connection_id  = ""
            },
          + {
              + carrier_gateway_id         = ""
              + cidr_block                 = "0.0.0.0/0"
              + core_network_arn           = ""
              + destination_prefix_list_id = ""
              + egress_only_gateway_id     = ""
              + gateway_id                 = "nat-xxxxxxxxxxx"
              + ipv6_cidr_block            = ""
              + local_gateway_id           = ""
              + nat_gateway_id             = ""
              + network_interface_id       = ""
              + transit_gateway_id         = ""
              + vpc_endpoint_id            = ""
              + vpc_peering_connection_id  = ""
            },
        ]
        tags             = {
            "Name" = "rt-private-us-west-2a"
        }
        # (5 unchanged attributes hidden)
    }
```

This patch does not seem to have any other effects other than removing the changeset each apply / plan

HTH